### PR TITLE
fix: wait for one second before check if a value is changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Please report any devices you've tested so that I can add to the list. Please op
 - Shelly 1 Gen4 (S4SW-001X16EU)
 - Shelly Plus 1 Gen2 (SNSW-001X16EU, SNSW-001X15UL)
 - Shelly Plus RGBW Gen2 (SNDC-0D4P10WW)
+- Shelly Uni Plus Gen2 (SNSN-0043X)
 
 ## Troubleshooting
 

--- a/src/components/Component.ts
+++ b/src/components/Component.ts
@@ -140,6 +140,7 @@ export abstract class Component {
       id: this.componentId,
       [setKey]: value
     })
+    await new Promise((resolve) => setTimeout(resolve, 1000))
     const status = await this.getStatus()
     if (JSON.stringify(status[getKey]) != JSON.stringify(value)) {
       throw new Error(

--- a/src/index.ts
+++ b/src/index.ts
@@ -355,7 +355,7 @@ const start = (app: ServerAPI) => {
     return props[`Device ID ${id}`]
   }
 
-  (plugin as any).createMockDevices = false
+  ;(plugin as any).createMockDevices = false
 
   return plugin
 }


### PR DESCRIPTION
Seems like some devices don't actually switch immediately, so wait for one second before checking for success.